### PR TITLE
2 container loading work (Seal no field)

### DIFF
--- a/ndd-app/booking/views/booking_data_view.py
+++ b/ndd-app/booking/views/booking_data_view.py
@@ -59,6 +59,7 @@ def booking_edit_summary(bookings):
         booking_save.pickup_from = re.sub(' +', ' ', booking['pickup_from'].strip())
         booking_save.return_to = re.sub(' +', ' ', booking['return_to'].strip())
         booking_save.container_no = re.sub(' +', ' ', booking['container_no'].strip())
+        booking_save.seal_no = re.sub(' +', ' ', booking['seal_no'].strip())
         booking_save.size = re.sub(' +', ' ', booking['size'].strip())
         booking_save.agent = re.sub(' +', ' ', booking['agent'].strip())
         booking_save.save()

--- a/ndd-app/templates/pdf_template/summary_print_template.html
+++ b/ndd-app/templates/pdf_template/summary_print_template.html
@@ -190,7 +190,13 @@
                         </td>
                         {% if 'container_2' in form %}
                             <td style="width: 3in;">
-                                {% if 'X' in inv_detail.work.size %}{{ inv_detail.work.container_2 }}{% endif %}
+                                {% if 'X' in inv_detail.work.size %}
+                                    {% if inv_detail.work.container_2 %}
+                                        {{ inv_detail.work.container_2 }}
+                                    {% elif inv_detail.work.seal_no %}
+                                        {{ inv_detail.work.seal_no }}
+                                    {% endif %}
+                                {% endif %}
                             </td>
                         {% endif %}
                         <td style="width: 1.6in;">
@@ -276,7 +282,13 @@
 
                                 {% if 'container_2' in form %}
                                     <td style="width: 3in;">
-                                        {% if 'X' in inv_detail.work.size %}{{ inv_detail.work.container_2 }}{% endif %}
+                                        {% if 'X' in inv_detail.work.size %}
+                                            {% if inv_detail.work.container_2 %}
+                                                {{ inv_detail.work.container_2 }}
+                                            {% elif inv_detail.work.seal_no %}
+                                                {{ inv_detail.work.seal_no }}
+                                            {% endif %}
+                                        {% endif %}
                                     </td>
                                 {% endif %}
 
@@ -495,7 +507,13 @@
 
                             {% if 'container_2' in form %}
                                 <td style="width: 3in;">
-                                    {{ inv_detail.work.container_2 }}
+                                    {% if 'X' in inv_detail.work.size %}
+                                        {% if inv_detail.work.container_2 %}
+                                            {{ inv_detail.work.container_2 }}
+                                        {% elif inv_detail.work.seal_no %}
+                                            {{ inv_detail.work.seal_no }}
+                                        {% endif %}
+                                    {% endif %}
                                 </td>
                             {% endif %}
 

--- a/ndd-app/templates/summary/summary_invoice_details.html
+++ b/ndd-app/templates/summary/summary_invoice_details.html
@@ -285,11 +285,25 @@
                                         {{ inv_detail.work.container_no }}
                                     </template>
                                 </td>
-                                <td v-if="customer_form.indexOf('container_2') > 0" class="text-center align-middle" >
-                                    <input v-if="table_edit" class="form-control text-center" 
-                                        :id="'4-'+index" @keydown="keyDownArrow(4, index)"
-                                        readonly
-                                    > 
+                                <td v-if="customer_form.indexOf('container_2') > 0" class="text-center align-middle" :class="container_color[inv_detail.detail.color2]">
+                                    <div v-if="inv_detail.work.size.indexOf('X') > -1">
+                                        <div v-if="table_edit" class="input-group" style="width: 160px;">
+                                            <input type="text" class="form-control text-center" style="padding: 2px 4px; margin: auto;"
+                                                :id="'4-'+index" @keydown="keyDownArrow(4, index)"
+                                                v-model="inv_detail.work.seal_no" maxlength="50"
+                                            >
+                                            <div class="input-group-append">
+                                                <button class="btn btn-sm btn-outline-secondary"
+                                                    style="padding: 4px;"
+                                                    @click="checkContainer(inv_detail.id, inv_detail.detail.color2, 2)"
+                                                >
+                                                <i class="fa fa-check"></i></button>
+                                            </div>
+                                        </div>
+                                        <template v-else>
+                                            {{ inv_detail.work.seal_no }}
+                                        </template>
+                                    </div>
                                 </td>
                             </template>
 
@@ -479,8 +493,8 @@
                                 <td class="text-center align-middle">
                                     {{ inv_detail.work.container_no }}
                                 </td>
-                                <td v-if="customer_form.indexOf('container_2') > 0">
-                                
+                                <td v-if="customer_form.indexOf('container_2') > 0" class="text-center align-middle">
+                                    <template v-if="inv_detail.work.size.indexOf('X') > -1">{{ inv_detail.work.seal_no }}</template>
                                 </td>
                             </template>
 


### PR DESCRIPTION
Use 'seal no' field for 'container 2' in loading work
- Edit booking
- Summary detail page
- Summary print template