### PR TITLE
Fix format number in summary report PDF

### DIFF
--- a/ndd-app/summary/templatetags/result.py
+++ b/ndd-app/summary/templatetags/result.py
@@ -8,17 +8,11 @@ def result(value):
         value = str(value)
         result = eval(value)
 
-        result = "{:,}".format(result)
+        result = "{:,.2f}".format(result)
 
         result = str(result)
-        x = result.split('.')
 
-        if len(x) == 1:
-            x.append('00')
-        elif len(x[1]) == 1:
-            x[1] = x[1] + '0'
-
-        return x[0] + '.' + x[1]
+        return result
     return '-'
 
 @register.filter(name='add_float')


### PR DESCRIPTION
Add `"{:,.2f}".format(result)` to fix format number